### PR TITLE
Fix the volatileGet to not revert with OutOfGas Error when key does not exist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ tracing = "0.1.37"
 once_cell = "1.19.0"
 reqwest = { version = "0.11.22", features = ["blocking"] }
 tiny_http = "0.12.0"
-regex = "1.10.2"
+regex = "1.10.3"
 redis = { version = "0.24.0", features = ["tokio-comp", "connection-manager"] }
 httptest = "0.15.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ tracing = "0.1.37"
 once_cell = "1.19.0"
 reqwest = { version = "0.11.22", features = ["blocking"] }
 tiny_http = "0.12.0"
-regex = "1.10.3"
+regex = "1.10.2"
 redis = { version = "0.24.0", features = ["tokio-comp", "connection-manager"] }
 httptest = "0.15.5"
 

--- a/examples/Andromeda.sol
+++ b/examples/Andromeda.sol
@@ -16,11 +16,10 @@ contract Andromeda {
 	require(success);
     }
 
-    function volatileGet(bytes32 key) public view returns (bool status, bytes32 val) {
+    function volatileGet(bytes32 key) public view returns (bytes memory) {
         (bool success, bytes memory value) = VOLATILEGET_ADDR.staticcall(abi.encodePacked((key)));
 	require(success);
-    // decode value into a boolean status and a bytes32 value
-    (status, val) = abi.decode(value, (bool, bytes32));
+    return abi.decode(value, (bytes));
     }
     
     function attestSgx(bytes memory userdata) public view returns (bytes memory) {

--- a/examples/Andromeda.sol
+++ b/examples/Andromeda.sol
@@ -16,11 +16,11 @@ contract Andromeda {
 	require(success);
     }
 
-    function volatileGet(bytes32 key) public view returns (bytes32) {
+    function volatileGet(bytes32 key) public view returns (bool status, bytes32 val) {
         (bool success, bytes memory value) = VOLATILEGET_ADDR.staticcall(abi.encodePacked((key)));
 	require(success);
-	require(value.length == 32);
-	return abi.decode(value, (bytes32));
+    // decode value into a boolean status and a bytes32 value
+    (status, val) = abi.decode(value, (bool, bytes32));
     }
     
     function attestSgx(bytes memory userdata) public view returns (bytes memory) {

--- a/examples/Andromeda.sol
+++ b/examples/Andromeda.sol
@@ -16,18 +16,16 @@ contract Andromeda {
 	require(success);
     }
 
-    function volatileGet(bytes32 key) public view returns (bool status, bytes32 val) {
+    function volatileGet(bytes32 key) public view returns (bytes memory) {
         (bool success, bytes memory value) = VOLATILEGET_ADDR.staticcall(abi.encodePacked((key)));
-	require(success);
-    require(value.length == 64);
-    // decode value into a boolean status and a bytes32 value
-    (status, val) = abi.decode(value, (bool, bytes32));
+        require(success);
+        return abi.decode(value, (bytes));
     }
     
     function attestSgx(bytes memory userdata) public view returns (bytes memory) {
         (bool success, bytes memory attestBytes) = ATTEST_ADDR.staticcall(userdata);
-	require(success);
-	return attestBytes;
+        require(success);
+        return attestBytes;
     }
 
     function localRandom() payable public returns (bytes32) {

--- a/examples/Andromeda.sol
+++ b/examples/Andromeda.sol
@@ -16,10 +16,12 @@ contract Andromeda {
 	require(success);
     }
 
-    function volatileGet(bytes32 key) public view returns (bytes memory) {
+    function volatileGet(bytes32 key) public view returns (bool status, bytes32 val) {
         (bool success, bytes memory value) = VOLATILEGET_ADDR.staticcall(abi.encodePacked((key)));
 	require(success);
-    return abi.decode(value, (bytes));
+    require(value.length == 64);
+    // decode value into a boolean status and a bytes32 value
+    (status, val) = abi.decode(value, (bool, bytes32));
     }
     
     function attestSgx(bytes memory userdata) public view returns (bytes memory) {

--- a/examples/andromeda_test.rs
+++ b/examples/andromeda_test.rs
@@ -40,7 +40,7 @@ fn simulate() -> eyre::Result<()> {
         "function localRandom() returns (bytes32)",
         "function attestSgx(bytes) returns (bytes)",
         "function volatileSet(bytes32,bytes32)",
-        "function volatileGet(bytes32) returns (bool, bytes32)",
+        "function volatileGet(bytes32) returns (bytes)",
         "function sha512(bytes) returns (bytes)",
         "struct HttpRequest { string url; string method; string[] headers; bytes body; bool withFlashbotsSignature; }",
         "function doHTTPRequest(HttpRequest memory request) returns (bytes memory)",
@@ -100,7 +100,7 @@ fn simulate() -> eyre::Result<()> {
         let _result = evm.transact()?;
         //dbg!(result);
     }
-        // Existing key test
+    // Existing key test
     {
         let calldata = abi.encode("volatileGet", (Token::FixedBytes(mykey),))?;
         evm.context.env.tx = TxEnv {
@@ -110,27 +110,19 @@ fn simulate() -> eyre::Result<()> {
             ..Default::default()
         };
         let result = evm.transact()?;
-        let decoded = ethabi::decode(
-            &[ethabi::ParamType::Bool, ethabi::ParamType::FixedBytes(32)],
-            result.result.output().unwrap(),
-        )?;
-        let status = match &decoded[0] {
-            Token::Bool(b) => b,
+        let decoded = ethabi::decode(&[ethabi::ParamType::Bytes], result.result.output().unwrap())?;
+        let val = match &decoded[0] {
+            Token::Bytes(b) => b,
             _ => todo!(),
         };
-        assert_eq!(status, &true);
-        let val = match &decoded[1] {
-            Token::FixedBytes(b) => b,
-            _ => todo!(),
-        };
-        assert_eq!(val.to_vec(), myval);
-
+        assert_eq!(val.to_vec(), myval.to_vec());
         dbg!(std::str::from_utf8(val).unwrap());
+
     }
-        // Non-existing key test
-    {
-        let nonExistingKey = "beefdeadbeefdeadbeefdeadbeefdead".as_bytes().to_vec();
-        let calldata = abi.encode("volatileGet", (Token::FixedBytes(nonExistingKey),))?;
+     // Non Existing key test
+     {
+        let notmykey = "deadbeefdeadbeefdeadbeefdeadbeff".as_bytes().to_vec();
+        let calldata = abi.encode("volatileGet", (Token::FixedBytes(notmykey),))?;
         evm.context.env.tx = TxEnv {
             caller: ADDR_A,
             transact_to: revm::primitives::TransactTo::Call(ADDR_B),
@@ -138,23 +130,16 @@ fn simulate() -> eyre::Result<()> {
             ..Default::default()
         };
         let result = evm.transact()?;
-        let decoded = ethabi::decode(
-            &[ethabi::ParamType::Bool, ethabi::ParamType::FixedBytes(32)],
-            result.result.output().unwrap(),
-        )?;
-        let status = match &decoded[0] {
-            Token::Bool(b) => b,
+        let decoded = ethabi::decode(&[ethabi::ParamType::Bytes], result.result.output().unwrap())?;
+        let val = match &decoded[0] {
+            Token::Bytes(b) => b,
             _ => todo!(),
         };
-        assert_eq!(status, &false);
-        let val = match &decoded[1] {
-            Token::FixedBytes(b) => b,
-            _ => todo!(),
-        };
-        assert_eq!(val.to_vec(), vec![0u8; 32]);
-        //dbg!(std::str::from_utf8(val).unwrap());
+        // empty vector 
+        let emptyvec: Vec<u8> = Vec::new();
+        assert_eq!(val.to_vec(), emptyvec.to_vec());
+        dbg!(std::str::from_utf8(val).unwrap());
     }
-
 
 
     //////////////////////////

--- a/examples/andromeda_test.rs
+++ b/examples/andromeda_test.rs
@@ -40,7 +40,7 @@ fn simulate() -> eyre::Result<()> {
         "function localRandom() returns (bytes32)",
         "function attestSgx(bytes) returns (bytes)",
         "function volatileSet(bytes32,bytes32)",
-        "function volatileGet(bytes32) returns (bytes)",
+        "function volatileGet(bytes32) returns (bool, bytes32)",
         "function sha512(bytes) returns (bytes)",
         "struct HttpRequest { string url; string method; string[] headers; bytes body; bool withFlashbotsSignature; }",
         "function doHTTPRequest(HttpRequest memory request) returns (bytes memory)",
@@ -84,7 +84,7 @@ fn simulate() -> eyre::Result<()> {
     //////////////////////////
     // Suave.volatileSet/Get
     //////////////////////////
-    let mykey: Vec<u8> = "deadbeefdeadbeefdeadbeefdeadbeef".as_bytes().to_vec();
+    let mykey = "deadbeefdeadbeefdeadbeefdeadbeef".as_bytes().to_vec();
     let myval = "cafebabecafebabecafebabecafebabe".as_bytes().to_vec();
     {
         let calldata = abi.encode(
@@ -100,7 +100,7 @@ fn simulate() -> eyre::Result<()> {
         let _result = evm.transact()?;
         //dbg!(result);
     }
-    // Existing key test
+        // Existing key test
     {
         let calldata = abi.encode("volatileGet", (Token::FixedBytes(mykey),))?;
         evm.context.env.tx = TxEnv {
@@ -110,19 +110,27 @@ fn simulate() -> eyre::Result<()> {
             ..Default::default()
         };
         let result = evm.transact()?;
-        let decoded = ethabi::decode(&[ethabi::ParamType::Bytes], result.result.output().unwrap())?;
-        let val = match &decoded[0] {
-            Token::Bytes(b) => b,
+        let decoded = ethabi::decode(
+            &[ethabi::ParamType::Bool, ethabi::ParamType::FixedBytes(32)],
+            result.result.output().unwrap(),
+        )?;
+        let status = match &decoded[0] {
+            Token::Bool(b) => b,
             _ => todo!(),
         };
-        assert_eq!(val.to_vec(), myval.to_vec());
-        dbg!(std::str::from_utf8(val).unwrap());
+        assert_eq!(status, &true);
+        let val = match &decoded[1] {
+            Token::FixedBytes(b) => b,
+            _ => todo!(),
+        };
+        assert_eq!(val.to_vec(), myval);
 
+        dbg!(std::str::from_utf8(val).unwrap());
     }
-     // Non Existing key test
-     {
-        let notmykey: Vec<u8> = "deadbeefdeadbeefdeadbeefdeadbeff".as_bytes().to_vec();
-        let calldata = abi.encode("volatileGet", (Token::FixedBytes(notmykey),))?;
+        // Non-existing key test
+    {
+        let nonExistingKey = "beefdeadbeefdeadbeefdeadbeefdead".as_bytes().to_vec();
+        let calldata = abi.encode("volatileGet", (Token::FixedBytes(nonExistingKey),))?;
         evm.context.env.tx = TxEnv {
             caller: ADDR_A,
             transact_to: revm::primitives::TransactTo::Call(ADDR_B),
@@ -130,16 +138,23 @@ fn simulate() -> eyre::Result<()> {
             ..Default::default()
         };
         let result = evm.transact()?;
-        let decoded = ethabi::decode(&[ethabi::ParamType::Bytes], result.result.output().unwrap())?;
-        let val = match &decoded[0] {
-            Token::Bytes(b) => b,
+        let decoded = ethabi::decode(
+            &[ethabi::ParamType::Bool, ethabi::ParamType::FixedBytes(32)],
+            result.result.output().unwrap(),
+        )?;
+        let status = match &decoded[0] {
+            Token::Bool(b) => b,
             _ => todo!(),
         };
-        // empty vector 
-        let emptyvec: Vec<u8> = Vec::new();
-        assert_eq!(val.to_vec(), emptyvec.to_vec());
-        dbg!(std::str::from_utf8(val).unwrap());
+        assert_eq!(status, &false);
+        let val = match &decoded[1] {
+            Token::FixedBytes(b) => b,
+            _ => todo!(),
+        };
+        assert_eq!(val.to_vec(), vec![0u8; 32]);
+        //dbg!(std::str::from_utf8(val).unwrap());
     }
+
 
 
     //////////////////////////

--- a/src/precompiles/sgxattest.rs
+++ b/src/precompiles/sgxattest.rs
@@ -132,19 +132,14 @@ fn sgxattest_volatile_get(input: &[u8], gas_limit: u64, env: &Env) -> Precompile
         let mut key: [u8; 52] = [0; 52];
         key[0..20].copy_from_slice(&domain_sep.0 .0);
         key[20..52].copy_from_slice(&input[0..32]);
-        let mut success = true;
-        let mut value = [0; 32];
+        let mut value = ethers::abi::encode(&[Token::Bytes(vec![])]);
         if let Some(val) = vol.get(&key) {
-           value = val.clone();
+            value = ethers::abi::encode(&[Token::Bytes(val.to_vec())]);
+            return Ok((gas_used, value.to_vec()));
         } else {
-            success = false;
+            // return empty value bytes if key does not exist
+            return Ok((gas_used, value.to_vec()));
         }
-        let result = &ethers::abi::encode(&[
-            Token::Bool(success),
-            Token::FixedBytes(value.to_vec()),
-        ]);
-         
-        return Ok((gas_used, result.to_vec()));    
     }
 }
 

--- a/src/precompiles/sgxattest.rs
+++ b/src/precompiles/sgxattest.rs
@@ -132,10 +132,19 @@ fn sgxattest_volatile_get(input: &[u8], gas_limit: u64, env: &Env) -> Precompile
         let mut key: [u8; 52] = [0; 52];
         key[0..20].copy_from_slice(&domain_sep.0 .0);
         key[20..52].copy_from_slice(&input[0..32]);
+        let mut success = true;
+        let mut value = [0; 32];
         if let Some(val) = vol.get(&key) {
-            return Ok((gas_used, val.to_vec()));
+           value = val.clone();
+        } else {
+            success = false;
         }
-        return Err(SGX_VOLATILE_KEY_MISSING);
+        let result = &ethers::abi::encode(&[
+            Token::Bool(success),
+            Token::FixedBytes(value.to_vec()),
+        ]);
+         
+        return Ok((gas_used, result.to_vec()));    
     }
 }
 

--- a/src/precompiles/sgxattest.rs
+++ b/src/precompiles/sgxattest.rs
@@ -132,14 +132,19 @@ fn sgxattest_volatile_get(input: &[u8], gas_limit: u64, env: &Env) -> Precompile
         let mut key: [u8; 52] = [0; 52];
         key[0..20].copy_from_slice(&domain_sep.0 .0);
         key[20..52].copy_from_slice(&input[0..32]);
-        let mut value = ethers::abi::encode(&[Token::Bytes(vec![])]);
+        let mut success = true;
+        let mut value = [0; 32];
         if let Some(val) = vol.get(&key) {
-            value = ethers::abi::encode(&[Token::Bytes(val.to_vec())]);
-            return Ok((gas_used, value.to_vec()));
+           value = val.clone();
         } else {
-            // return empty value bytes if key does not exist
-            return Ok((gas_used, value.to_vec()));
+            success = false;
         }
+        let result = &ethers::abi::encode(&[
+            Token::Bool(success),
+            Token::FixedBytes(value.to_vec()),
+        ]);
+         
+        return Ok((gas_used, result.to_vec()));    
     }
 }
 


### PR DESCRIPTION
In this PR:
We fixed the issue with volatileGet precompile function upon calling it with key that doesnt exist.
It returns an err, however, it also reverts the whole execution with OutOfGas (gas_used =18158513697557840303)
To avoid such an issue and still be able to handle a non-existing key from the smart contract side:
1- Instead of reverting with an error, we return a status and a value. The status would mark if the key exists or not.
If the key exists, the value will be set accordingly. If not, it will return 0 bytes array with a failure status (false) 
2- Added unit tests for existing and non-existing keys
